### PR TITLE
[TN-51] Reviewers/Assignees 할당 Github action 추가

### DIFF
--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -1,0 +1,44 @@
+name: Assign Reviewer and Notify
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  assign-reviewer-and-notify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Assign PR creator as assignee
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.ACTION_TOKEN }}
+          script: |
+            const assignee = context.payload.pull_request.user.login;
+            github.issues.addAssignees({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              assignees: [assignee]
+            });
+
+      - name: Select reviewer
+        id: select-reviewer
+        run: |
+          assignee=$(echo "${{ github.event.pull_request.user.login }}")
+          members=("lyoodong" "limsub") 
+          reviewers=()
+          for member in "${members[@]}"; do
+            if [ "$member" != "$assignee" ]; then
+              reviewers+=("$member")
+            fi
+          done
+          reviewer=${reviewers[$RANDOM % ${#reviewers[@]}]}
+          echo "::set-output name=reviewer::$reviewer"
+          
+      - name: Assign reviewer
+        uses: madrapps/add-reviewers@v1
+        with:
+          reviewers: ${{ steps.select-reviewer.outputs.reviewer }}
+          token: ${{ secrets.ACTION_TOKEN }}
+


### PR DESCRIPTION
### PR 작성전 체크 목록

다음 사항들을 체크했는지 확인해봅시다:

- [x]  base branch 꼭 확인하세요!
- [x]  커밋 메세지들이 약속된 형태로 작성되었나요?
- [x]  추가된 내용 또는 수정된 버그에 대해 충분히 테스트 하였나요?
- [x]  아래의 PR 문서에 작성된 내용으로 충분히 공유가 되거나, 문서를 별도로 작성하였나요?

### PR 타입

해당 PR의 주요한 목적은 다음과 같습니다.

- [ ]  Feature
- [ ]  Feature-Append
- [ ]  UI Design
- [ ]  QA Fix
- [ ]  Bugfix
- [ ]  Code style update (formatting, local variables)
- [ ]  Refactoring (no functional changes, no api changes)
- [ ]  Build related changes
- [x]  CI related changes
- [ ]  Documentation content changes
- [ ]  Others

### 관련 지라 티켓 번호

Issue Number: TTOON-51

### 주요 내용
- PR을 생성한 사람을 assignee로 자동 할당
- assignee를 제외한 팀원 중 1명을 reviewer로 할당
- 선택된 리뷰어 할당
- TODO
  - 슬랙에 메세지 전송
<img width="639" alt="스크린샷 2024-03-31 오후 5 42 32" src="https://github.com/TToon-main/ttoon-ios/assets/115209527/92ed422d-1ea5-4d77-a251-ae8f3bcb4ca4">

참고
https://velog.io/@parkjisu6239/Github-Actions-과-CICD-랜덤-리뷰어-뽑기
https://toss.tech/article/25431

### 스크린샷
