### PR TITLE
[NO-ISSUE] 프로필 수정 API 개발 오류 수정

### DIFF
--- a/TTOON/Data/API/Home/Friend/FriendAPI.swift
+++ b/TTOON/Data/API/Home/Friend/FriendAPI.swift
@@ -87,4 +87,8 @@ extension FriendAPI: TargetType {
             ]
         }
     }
+    
+    var validationType: ValidationType {
+        return .successCodes
+    }
 }

--- a/TTOON/Data/API/Setting/SettingAPI.swift
+++ b/TTOON/Data/API/Setting/SettingAPI.swift
@@ -75,9 +75,9 @@ extension SettingAPI: TargetType {
                 multipartData.append(MultipartFormData(provider: .data(imageData), name: "file", fileName: "\(UUID().uuidString).jpg", mimeType: "image/jpeg"))
             }
             
-            let params: [String: String] = [
+            let params: [String: Any] = [
                 "nickName": dto.nickName,
-                "isDelete": "\(dto.isDelete)"
+                "isDelete": dto.isDelete
             ]
             
             if multipartData.isEmpty {
@@ -96,8 +96,27 @@ extension SettingAPI: TargetType {
         case .deleteAccount:
             return [ "sender": "app"]
             
+        case .patchProfile(let dto):
+            let token = KeychainStorage.shared.accessToken ?? "" 
+
+            if dto.image == nil {
+                return [
+                    "Content-Type": "application/application/json",
+                    "Authorization": "Bearer \(token)"
+                ]
+            } else {
+                return [
+                    "Content-Type": "multipart/form-data",
+                    "Authorization": "Bearer \(token)"
+                ]
+            }
+            
         default:
             return nil
         }
+    }
+    
+    var validationType: ValidationType {
+        return .successCodes
     }
 }

--- a/TTOON/Data/Repository/Setting/MyPageRepository.swift
+++ b/TTOON/Data/Repository/Setting/MyPageRepository.swift
@@ -21,7 +21,7 @@ class MyPageRepository: MyPageRepositoryProtocol {
     }
     
     func patchProfile(dto: PatchProfileRequestDTO) -> Observable<Bool> {
-        return provider.auth.rx.request(.patchProfile(dto: dto))
+        return provider.unAuth.rx.request(.patchProfile(dto: dto))
             .map(ResponseDTO<String>.self)
             .map { $0.isSuccess }
             .asObservable()

--- a/TTOON/Presentation/Setting/MyPage/View/ProfileSetView.swift
+++ b/TTOON/Presentation/Setting/MyPage/View/ProfileSetView.swift
@@ -195,10 +195,8 @@ extension Reactive where Base: ProfileSetView {
         return base.saveButton.rx.tap
             .map { _ in
                 let nickName = base.nickNameTextFiled.textFiled.text ?? ""
-                
-                let isDelete = base.profileImageView.image == TNImage.userIcon
-                
-                let image: UIImage? = isDelete ? nil : base.profileImageView.image
+                let isDelete = false
+                let image: UIImage? = base.profileImageView.image 
                 
                 return SetProfileRequestModel(nickName: nickName, isDelete: isDelete, image: image)
             }


### PR DESCRIPTION
- 프로필 수정 API 수정
- interceptor의 retry 실행을 위해 API에 validationType을 .successCodes로 변경

### PR 작성전 체크 목록

다음 사항들을 체크했는지 확인해봅시다:

- [x]  base branch 꼭 확인하세요!
- [x]  커밋 메세지들이 약속된 형태로 작성되었나요?
- [x]  추가된 내용 또는 수정된 버그에 대해 충분히 테스트 하였나요?
- [x]  아래의 PR 문서에 작성된 내용으로 충분히 공유가 되거나, 문서를 별도로 작성하였나요?

### PR 타입

해당 PR의 주요한 목적은 다음과 같습니다.

- [ ]  Feature
- [ ]  Feature-Append
- [ ]  UI Design
- [ ]  QA Fix
- [x]  Bugfix
- [ ]  Code style update (formatting, local variables)
- [ ]  Refactoring (no functional changes, no api changes)
- [ ]  Build related changes
- [ ]  CI related changes
- [ ]  Documentation content changes
- [ ]  Others

### 관련 지라 티켓 번호

Issue Number: NO-ISSUE

### 주요 내용
1. patchProfile이 정상 동작하지 않았던 부분을 개선했습니다.
- 쿼리 파라미터의 타입 미스(string -> Bool)
- 헤더의 Content-Type 미스
- 이미지 수정 여부에 따라, 전송 방식을 분기 처리했습니다.

2. 이미지 삭제
- 서버의 스펙에서는 이미지를 삭제할 경우, formData에 nil을 보내면 된다고 했으나, 현재 Moya에서는 formData를 nil로 보낼 수 없었습니다. 따라서 삭제인 경우에 약간의 트릭을 써서, 기본 이미지를 보내고 있습니다.

3. interceptor의 retry 메서드 실행을 위한, validationType 추가
- retry 메서드는 request에 대한 응답이 '실패'로 처리되었을 때 실행됩니다.
- 즉 상태코드가, 401이라도 이를 '성공'으로 처리 시 retry 메서드가 실행되지 않습니다.
- 따라서 200...299까지의 상태만 '성공'으로 처리하기 위해, validationType을 `.successCodes`로 지정했습니다.


### 스크린샷
