### PR TITLE
[TN-215] 캐릭터 선택 시트 UI 데이터 바인딩, 일기 입력화면 UI 데이터 바인딩

### DIFF
--- a/TTOON/Data/API/Setting/SettingAPI.swift
+++ b/TTOON/Data/API/Setting/SettingAPI.swift
@@ -99,17 +99,10 @@ extension SettingAPI: TargetType {
         case .patchProfile(let dto):
             let token = KeychainStorage.shared.accessToken ?? "" 
 
-            if dto.image == nil {
-                return [
-                    "Content-Type": "application/application/json",
-                    "Authorization": "Bearer \(token)"
-                ]
-            } else {
-                return [
-                    "Content-Type": "multipart/form-data",
-                    "Authorization": "Bearer \(token)"
-                ]
-            }
+            return [
+                "Content-Type": "multipart/form-data",
+                "Authorization": "Bearer \(token)"
+            ]
             
         default:
             return nil

--- a/TTOON/Domain/Entity/Toon/ToonModel.swift
+++ b/TTOON/Domain/Entity/Toon/ToonModel.swift
@@ -14,7 +14,8 @@ struct Character {
     let info: String
     
     func toPresenter() -> CharacterPickerTableViewCellDataSource {
-        return .init(name: name,
+        return .init(id: id,
+                     name: name,
                      isMainCharacter: isMain,
                      characterDescription: info,
                      isSelected: false,

--- a/TTOON/Presentation/Attendance/View/AttendanceScrollView.swift
+++ b/TTOON/Presentation/Attendance/View/AttendanceScrollView.swift
@@ -59,7 +59,6 @@ extension Reactive where Base: AttendanceScrollView {
     
     var showInvalid: Binder<Bool> {
         return Binder(base) { view, isInvalid in
-            print("디버그", isInvalid)
         }
     }
     

--- a/TTOON/Presentation/CustomView/Toon/CreateToon/CharacterPickerTableViewCell.swift
+++ b/TTOON/Presentation/CustomView/Toon/CreateToon/CharacterPickerTableViewCell.swift
@@ -10,10 +10,11 @@ import UIKit
 import RxSwift
 
 struct CharacterPickerTableViewCellDataSource {
-    let name: String?
+    let id: String
+    let name: String
     let isMainCharacter: Bool
-    let characterDescription: String?
-    let isSelected: Bool
+    let characterDescription: String
+    var isSelected: Bool
     let isModify: Bool
 }
 
@@ -98,10 +99,31 @@ class CharacterPickerTableViewCell: BaseTableViewCell {
         contentView.addSubview(modifyCharacterButton)
         contentView.addSubview(lineDiver)
     }
-    
-    override func layoutSubviews() {
+
+	override func layoutSubviews() {
         super.layoutSubviews()
-        contentView.frame = contentView.frame.inset(by: UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16))
+        contentView.frame = contentView.frame.inset(by: UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
+    }
+    
+    func setCell(_ item: CharacterPickerTableViewCellDataSource) {
+        titleLabel.text = item.name
+        subTitleLabel.text = item.characterDescription
+        modifyCharacterButton.isHidden = !item.isModify
+        mainCharacterButton.isHidden = !item.isMainCharacter
+        setIsSelected(item.isSelected)
+    }
+    
+    private func setIsSelected(_ isSelected: Bool) {
+        checkImageView.isHidden = !isSelected
+        
+        if isSelected {
+            titleLabel.textColor = .grey08
+            subTitleLabel.textColor = .grey07
+        } else {
+            [titleLabel, subTitleLabel].forEach { t in
+                t.textColor = .grey05
+            }
+        }
     }
     
     override func layouts() {

--- a/TTOON/Presentation/CustomView/Toon/CreateToon/CharacterPickerTableViewCell.swift
+++ b/TTOON/Presentation/CustomView/Toon/CreateToon/CharacterPickerTableViewCell.swift
@@ -102,7 +102,7 @@ class CharacterPickerTableViewCell: BaseTableViewCell {
 
 	override func layoutSubviews() {
         super.layoutSubviews()
-        contentView.frame = contentView.frame.inset(by: UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
+        contentView.frame = contentView.frame.inset(by: UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16))
     }
     
     func setCell(_ item: CharacterPickerTableViewCellDataSource) {
@@ -159,13 +159,5 @@ class CharacterPickerTableViewCell: BaseTableViewCell {
             $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalToSuperview()
         }
-    }
-    
-    func setCell(_ item: CharacterPickerTableViewCellDataSource) {
-        titleLabel.text = item.name
-        subTitleLabel.text = item.characterDescription
-        checkImageView.isHidden = !item.isSelected
-        modifyCharacterButton.isHidden = !item.isModify
-        mainCharacterButton.isHidden = !item.isMainCharacter
     }
 }

--- a/TTOON/Presentation/CustomView/Toon/CreateToon/CreateToonDiaryView.swift
+++ b/TTOON/Presentation/CustomView/Toon/CreateToon/CreateToonDiaryView.swift
@@ -31,7 +31,8 @@ class CreateToonDiaryView: BaseView {
     let diaryTitleTextField = {
         let view = TNTextFiled()
         view.textFiled.placeholder = "제목을 입력해주세요"
-        view.statusLabel.textCntLabel.text = "0/20"
+        view.statusLabel.textCntLabel.text = "0"
+        view.statusLabel.textLimitLabel.text = "/20"
         
         return view
     }()
@@ -46,10 +47,9 @@ class CreateToonDiaryView: BaseView {
     }()
     
     let dairyLimitTextView = {
-        let view = UILabel()
-        view.font = .body14r
-        view.textColor = .grey05
-        view.text = "0/200"
+        let view = TextStatusView()
+        view.textCntLabel.text = "0"
+        view.textLimitLabel.text = "/200"
         
         return view
     }()
@@ -87,25 +87,10 @@ class CreateToonDiaryView: BaseView {
         }
         
         dairyLimitTextView.snp.makeConstraints {
-            $0.trailing.equalToSuperview()
             $0.top.equalTo(diaryInputTextView.snp.bottom).offset(4)
+            $0.horizontalEdges.equalToSuperview()
             $0.height.equalTo(20)
             $0.bottom.equalToSuperview()
         }
-    }
-    
-    override func bind() {
-        diaryInputTextView.rx.text
-            .filter { $0 != self.diaryInputTextView.placeholderText }
-            .compactMap { $0 }
-            .map{ "\($0.count)/\(self.diaryInputTextView.limitCnt)"}
-            .bind(to: dairyLimitTextView.rx.text)
-            .disposed(by: disposeBag)
-        
-        diaryTitleTextField.textFiled.rx.text
-            .compactMap { $0 }
-            .map{ "\($0.count)/20"}
-            .bind(to: diaryTitleTextField.rx.cntText)
-            .disposed(by: disposeBag)
     }
 }

--- a/TTOON/Presentation/CustomView/Toon/CreateToon/CreateToonSelectCharactersButton.swift
+++ b/TTOON/Presentation/CustomView/Toon/CreateToon/CreateToonSelectCharactersButton.swift
@@ -7,10 +7,30 @@
 
 import UIKit
 
+import RxCocoa
+import RxSwift
+
 class CreateToonSelectCharactersButton: UIButton {
+    // MARK: - UI Properties
+    
+    private let btnTitleLabel = UILabel()
+    private let arrowImageView = UIImageView()
+    
+    private lazy var container = {
+        let view = UIStackView()
+        view.addArrangedSubview(btnTitleLabel)
+        view.addArrangedSubview(arrowImageView)
+        view.spacing = 11
+        
+        return view
+    }()
+    
+    // MARK: - Initialize
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         configure()
+        layouts()
     }
     
     @available(*, unavailable)
@@ -18,13 +38,42 @@ class CreateToonSelectCharactersButton: UIButton {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // MARK: - Configurations
+    
     private func configure() {
+        btnTitleLabel.font = .body16m
+        container.isUserInteractionEnabled = false
         backgroundColor = .grey01
-        titleLabel?.font = .body16m
-        setTitleColor(.grey06, for: .normal)
-        setTitle("저장해둔 등장인물 중 선택해주세요", for: .normal)
-        setImage(TNImage.btnArrowDownIcon, for: .normal)
         layer.cornerRadius = 8
-        configureButtonLayout(leadingInset: 20, spacing: 68, semanticAttribute: .forceRightToLeft)
+        semanticContentAttribute = .forceRightToLeft
+        
+        setDefaultText()
+    }
+    
+    private func layouts() {
+        addSubview(container)
+        
+        container.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview().inset(20)
+            $0.centerY.equalToSuperview()
+        }
+        
+        arrowImageView.snp.makeConstraints {
+            $0.size.equalTo(22)
+        }
+    }
+    
+    // MARK: - Methods
+    
+    func setSelectedCharactersText(_ text: String) {
+        btnTitleLabel.text = text
+        btnTitleLabel.textColor = .grey08
+        arrowImageView.image = TNImage.btnArrowDownIcon?.withTintColor(.black)
+    }
+    
+    func setDefaultText() {
+        btnTitleLabel.text = "저장해둔 등장인물 중 선택해주세요"
+        btnTitleLabel.textColor = .grey06
+        arrowImageView.image = TNImage.btnArrowDownIcon
     }
 }

--- a/TTOON/Presentation/Toon/CreateToon/View/CharacterPickerBSView.swift
+++ b/TTOON/Presentation/Toon/CreateToon/View/CharacterPickerBSView.swift
@@ -53,6 +53,7 @@ class CharacterPickerBSView: BaseView {
     let confirmButton = {
         let view = TNButton()
         view.setTitle("완료", for: .normal)
+        view.isEnabled = false
         
         return view
     }()
@@ -120,6 +121,28 @@ extension Reactive where Base: CharacterPickerBSView {
         return Binder(base) { view, isHidden in
             view.invalidView.isHidden = isHidden
         }
+    }
+    
+    var isEnabledConfirmButton: Binder<Bool> {
+        return base.confirmButton.rx.isEnabled
+    }
+}
+
+extension Reactive where Base: CharacterPickerBSView {
+    var confirmButtonTap: Observable<Void> {
+        return base.confirmButton.rx.tap
+            .asObservable()
+    }
+    
+    var modifyCharacterButtonTap: Observable<Void> {
+        return base.modifyCharacterButton.rx.tap
+            .asObservable()
+    }
+    
+    var modelSelected: Observable<CharacterPickerTableViewCellDataSource> {
+        return base.tableView.rx
+            .modelSelected(CharacterPickerTableViewCellDataSource.self)
+            .asObservable()
     }
 }
  

--- a/TTOON/Presentation/Toon/CreateToon/View/EnterInfoScrollView.swift
+++ b/TTOON/Presentation/Toon/CreateToon/View/EnterInfoScrollView.swift
@@ -44,14 +44,18 @@ class EnterInfoScrollView: BaseView {
 }
 
 extension Reactive where Base: EnterInfoScrollView {
-    var textFieldDidChange: Observable<EnterInfoReactor.Action> {
+    var dairyTextViewDidChange: Observable<EnterInfoReactor.Action> {
         let diaryInputTextView = base.enterInfoView.enterDiaryTextView.diaryInputTextView
         
         return diaryInputTextView.rx.text
             .compactMap { $0 }
             .filter { $0 != diaryInputTextView.placeholderText }
             .distinctUntilChanged()
-            .map { EnterInfoReactor.Action.textFieldDidChange($0)}
+            .map { EnterInfoReactor.Action.dairyTextViewDidChange($0)}
+    }
+    
+    var titleTextFieldTextDidChange: Observable<String> {
+        return base.enterInfoView.enterDiaryTextView.diaryTitleTextField.rx.textDidChanged
     }
     
     var confirmButtonTap: Observable<EnterInfoReactor.Action> {
@@ -84,5 +88,25 @@ extension Reactive where Base: EnterInfoScrollView {
                     .setDefaultText()
             }
         }
+    }
+    
+    var titleTextFiledError: Binder<String?> {
+        return base.enterInfoView.enterDiaryTextView.diaryTitleTextField.rx.errorMassage
+    }
+    
+    var titleTextFieldTextCount: Binder<String?> {
+        return base.enterInfoView.enterDiaryTextView.diaryTitleTextField.rx.cntText
+    }
+    
+    var dairyTextViewError: Binder<String?> {
+        return base.enterInfoView.enterDiaryTextView.dairyLimitTextView.rx.errorMassage
+    }
+    
+    var dairyTextViewTextCount: Binder<String?> {
+        return base.enterInfoView.enterDiaryTextView.dairyLimitTextView.rx.cntText
+    }
+    
+    var isEnabledConfirmButton: Binder<Bool> {
+        return base.enterInfoView.confirmButton.rx.isEnabled
     }
 }

--- a/TTOON/Presentation/Toon/CreateToon/View/EnterInfoScrollView.swift
+++ b/TTOON/Presentation/Toon/CreateToon/View/EnterInfoScrollView.swift
@@ -71,4 +71,18 @@ extension Reactive where Base: EnterInfoScrollView {
             view.enterInfoView.enterDiaryTextView.diaryInputTextView.text = text
         }
     }
+    
+    var characterButtonText: Binder<String?> {
+        return Binder(base) { view, text in
+            if let text = text {
+                base.enterInfoView.selectCharactersView
+                    .selectCharactersButton
+                    .setSelectedCharactersText(text)
+            } else {
+                base.enterInfoView.selectCharactersView
+                    .selectCharactersButton
+                    .setDefaultText()
+            }
+        }
+    }
 }

--- a/TTOON/Presentation/Toon/CreateToon/View/EnterInfoView.swift
+++ b/TTOON/Presentation/Toon/CreateToon/View/EnterInfoView.swift
@@ -27,6 +27,7 @@ class EnterInfoView: BaseView {
     let confirmButton = {
         let view = TNButton()
         view.setTitle("완료", for: .normal)
+        view.isEnabled = false
         
         return view
     }()

--- a/TTOON/Presentation/Toon/CreateToon/ViewController/CharacterModifyViewController.swift
+++ b/TTOON/Presentation/Toon/CreateToon/ViewController/CharacterModifyViewController.swift
@@ -46,7 +46,7 @@ class CharacterModifyViewController: BaseViewController {
     
     // TODO: 임시
     func bindMockUp() {
-        let characterData = CharacterPickerTableViewCellDataSource(name: "이름 1", isMainCharacter: true, characterDescription: "캐릭터에 대한 묘사 및 설명", isSelected: false, isModify: true)
+        let characterData = CharacterPickerTableViewCellDataSource(id: "", name: "이름 1", isMainCharacter: true, characterDescription: "캐릭터에 대한 묘사 및 설명", isSelected: false, isModify: true)
         let mockUpData = Array(repeating: characterData, count: 20)
         let modifyButtonTap = PublishSubject<Void>()
         

--- a/TTOON/Presentation/Toon/CreateToon/ViewController/CreateToonBaseViewController.swift
+++ b/TTOON/Presentation/Toon/CreateToon/ViewController/CreateToonBaseViewController.swift
@@ -16,6 +16,7 @@ class CreateToonBaseViewController: BaseViewController {
     
     lazy var orangeProgressDefaultWidth = width - 36
     var orangeProgressWidthConstraint: Constraint?
+    var greyProgressWidthConstraint: Constraint?
     
     // MARK: - UI Properties
     
@@ -74,8 +75,12 @@ extension Reactive where Base: CreateToonBaseViewController {
     var currentProgress: Binder<Float> {
         return Binder(base) { vc, progress in
             UIView.animate(withDuration: 0.5, delay: 0, options: .curveEaseInOut) {
+                let isHiddenGreyBar = progress == 1.0
+                vc.greyProgressBar.isHidden = isHiddenGreyBar
+                
                 let width = vc.orangeProgressDefaultWidth * CGFloat(progress)
                 vc.orangeProgressWidthConstraint?.update(offset: width)
+                
                 vc.view.layoutIfNeeded()
             }
         }

--- a/TTOON/Presentation/Toon/CreateToon/ViewController/EnterInfoViewController.swift
+++ b/TTOON/Presentation/Toon/CreateToon/ViewController/EnterInfoViewController.swift
@@ -43,7 +43,7 @@ extension EnterInfoViewController: View {
     }
     
     func bindAction(reactor: EnterInfoReactor) {
-        enterInfoScrollView.rx.textFieldDidChange
+        enterInfoScrollView.rx.dairyTextViewDidChange
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
@@ -54,14 +54,14 @@ extension EnterInfoViewController: View {
         enterInfoScrollView.rx.confirmButtonTap
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
+        
+        enterInfoScrollView.rx.titleTextFieldTextDidChange
+            .map{ EnterInfoReactor.Action.titleTextFieldTextDidChange($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
     }
     
     func bindState(reactor: EnterInfoReactor) {
-        reactor.state
-            .map { $0.validTextFieldText }
-            .bind(to: enterInfoScrollView.rx.validTextFieldText)
-            .disposed(by: disposeBag)
-        
         reactor.state
             .compactMap { $0.presentCharacterPickerBS }
             .bind(onNext: presentCharacterPickerBS)
@@ -84,6 +84,28 @@ extension EnterInfoViewController: View {
         
         reactor.state.compactMap { $0.characterButtonText }
             .bind(to: enterInfoScrollView.rx.characterButtonText)
+            .disposed(by: disposeBag)
+        
+        reactor.state.map { $0.titleTextFieldError }
+            .distinctUntilChanged()
+            .bind(to: enterInfoScrollView.rx.titleTextFiledError)
+            .disposed(by: disposeBag)
+        
+        reactor.state.map { $0.dairyTextViewError }
+            .distinctUntilChanged()
+            .bind(to: enterInfoScrollView.rx.dairyTextViewError)
+            .disposed(by: disposeBag)
+        
+        reactor.state.compactMap { $0.dairyTextViewTextCount }
+            .bind(to: enterInfoScrollView.rx.dairyTextViewTextCount)
+            .disposed(by: disposeBag)
+        
+        reactor.state.compactMap { $0.titleTextFieldTextCount }
+            .bind(to: enterInfoScrollView.rx.titleTextFieldTextCount)
+            .disposed(by: disposeBag)
+        
+        reactor.state.map { $0.isEnabledConfirmButton }
+            .bind(to: enterInfoScrollView.rx.isEnabledConfirmButton)
             .disposed(by: disposeBag)
     }
 }

--- a/TTOON/Presentation/Toon/CreateToon/ViewModel/CharacterPickerBSReactor.swift
+++ b/TTOON/Presentation/Toon/CreateToon/ViewModel/CharacterPickerBSReactor.swift
@@ -8,8 +8,14 @@
 import ReactorKit
 import RxSwift
 
+protocol CharacterPickerBSDelegate: AnyObject {
+    func presentModifyCharacterViewController()
+    func selectedCharacters(selectedModels: [CharacterPickerTableViewCellDataSource])
+}
+
 final class CharacterPickerBSReactor: Reactor {
     private let useCase: ToonUseCaseProtocol
+    weak var delegate: CharacterPickerBSDelegate?
     
     init(useCase: ToonUseCaseProtocol) {
         self.useCase = useCase
@@ -18,20 +24,27 @@ final class CharacterPickerBSReactor: Reactor {
     // 뷰에서 입력받은 유저 이벤트
     enum Action {
         case refreshCharacterList
+        case modifyCharacterButtonTap
+        case confirmButtonTap
+        case modelSelected(model: CharacterPickerTableViewCellDataSource)
     }
     
     // Action과 State의 매개체
     enum Mutation {
-        case setCharacterList(list: [Character])
+        case setCharacterList(list: [CharacterPickerTableViewCellDataSource])
         case setEmptyList(isEmpty: Bool)
         case setInvalidList(isInvalid: Bool)
+        case setDismiss(isDismiss: Bool)
+        case setIsEnabledConfirmButton(isEnabled: Bool)
     }
     
     // 뷰에 전달할 상태
     struct State {
-        var characterList: [Character]? = nil
+        var characterList: [CharacterPickerTableViewCellDataSource]? = nil
         var isHiddenEmptyView: Bool = true
         var isHiddenInvalidView: Bool = true
+        var isDismiss: Bool = false
+        var isEnabledConfirmButton: Bool = false
     }
     
     // 전달할 상태의 초기값
@@ -44,7 +57,8 @@ final class CharacterPickerBSReactor: Reactor {
                 .map { status in
                     switch status {
                     case .valid(let list):
-                        return Mutation.setCharacterList(list: list)
+                        let dataSource = list.map { $0.toPresenter() }
+                        return Mutation.setCharacterList(list: dataSource)
                         
                     case .empty:
                         return Mutation.setEmptyList(isEmpty: true)
@@ -53,6 +67,35 @@ final class CharacterPickerBSReactor: Reactor {
                         return Mutation.setInvalidList(isInvalid: true)
                     }
                 }
+            
+        case .confirmButtonTap:
+            self.sendSelectedModels()
+            return .just(.setDismiss(isDismiss: true))
+            
+        case .modifyCharacterButtonTap:
+            self.presentModifyCharacterVC()
+            return .just(.setDismiss(isDismiss: true))
+            
+        case .modelSelected(let model):
+            guard let characterList = currentState.characterList else {
+                return .never()
+            }
+            
+            let list = characterList
+                .map { dataSource in
+                    var new = dataSource
+                    
+                    if dataSource.id == model.id {
+                        new.isSelected.toggle()
+                    }
+                    
+                    return new
+                }
+            
+            let isEnabled = !list.map { $0.isSelected }.filter { $0 }.isEmpty
+            
+            return .concat(.just(.setCharacterList(list: list)),
+                           .just(.setIsEnabledConfirmButton(isEnabled: isEnabled)))
         }
     }
     
@@ -71,6 +114,14 @@ final class CharacterPickerBSReactor: Reactor {
         case .setInvalidList(let isInvalid):
             newState.isHiddenInvalidView = !isInvalid
             return newState
+            
+        case .setDismiss(let isDismiss):
+            newState.isDismiss = isDismiss
+            return newState
+            
+        case .setIsEnabledConfirmButton(let isEnabled):
+            newState.isEnabledConfirmButton = isEnabled
+            return newState
         }
     }
     
@@ -80,5 +131,19 @@ final class CharacterPickerBSReactor: Reactor {
         new.isHiddenInvalidView = true
         
         return new
+    }
+    
+    func sendSelectedModels() {
+        guard let characterList = currentState.characterList else {
+            return
+        }
+        
+        let selectedModels = characterList.filter({ $0.isSelected })
+        
+        delegate?.selectedCharacters(selectedModels: selectedModels)
+    }
+    
+    func presentModifyCharacterVC() {
+        delegate?.presentModifyCharacterViewController()
     }
 }


### PR DESCRIPTION
### PR 작성전 체크 목록

다음 사항들을 체크했는지 확인해봅시다:

- [x]  base branch 꼭 확인하세요!
- [x]  커밋 메세지들이 약속된 형태로 작성되었나요?
- [x]  추가된 내용 또는 수정된 버그에 대해 충분히 테스트 하였나요?
- [ ]  아래의 PR 문서에 작성된 내용으로 충분히 공유가 되거나, 문서를 별도로 작성하였나요?

### PR 타입

해당 PR의 주요한 목적은 다음과 같습니다.

- [ ]  Feature
- [ ]  Feature-Append
- [x]  UI Design
- [ ]  QA Fix
- [ ]  Bugfix
- [ ]  Code style update (formatting, local variables)
- [ ]  Refactoring (no functional changes, no api changes)
- [ ]  Build related changes
- [ ]  CI related changes
- [ ]  Documentation content changes
- [ ]  Others

### 관련 지라 티켓 번호

Issue Number: TTOON-215

### 주요 내용
- 캐릭터 선택 바텀 시트에서 '캐릭터 선택'했을 경우 UI를 변경했습니다.(체크 박스 표시, textOpacity 변경)
- 선택된 캐릭터의 name이 '일기 입력' 화면의 텍스트로 이동하게 변경했습니다.
- '일기 입력' 화면의 UI로직을 바인딩했습니다.(글자수, 확인 버튼 활성화)

### 스크린샷
<img width="682" alt="스크린샷 2024-10-09 오후 5 47 52" src="https://github.com/user-attachments/assets/08a2c6a7-4bd3-42c4-9ee7-103389751cbf">
