### PR TITLE
[QA] 친구요청 받은 상대를 수락하지 않은 상태로 검색했을 때 ‘이미 받은 상태에요’ 팝업 처리

### DIFF
--- a/TTOON/Data/Repository/Friend/ReceivedFriendRequestRepository.swift
+++ b/TTOON/Data/Repository/Friend/ReceivedFriendRequestRepository.swift
@@ -36,7 +36,7 @@ class ReceivedFriendRequestRepository: NSObject, ReceivedFriendRequestRepository
             // 1. dto 변환 없음
             
             // 2. 요청
-            let request = self.provider.auth.request(.receivedRequestList(page: page)) { result in
+            let request = self.provider.log.request(.receivedRequestList(page: page)) { result in
                 switch result {
                 case .success(let response):
                     if let data = try? response.map(ResponseDTO<[UserInfoDTO]>.self),

--- a/TTOON/Data/Repository/Friend/SearchFriendRepository.swift
+++ b/TTOON/Data/Repository/Friend/SearchFriendRepository.swift
@@ -14,7 +14,7 @@ import RxSwift
 
 protocol SearchFriendRepositoryProtocol {
     func searchUserList(_ requestModel: UserListRequestModel) -> Single< Result<[SearchedUserInfoModel], Error> >
-    func requestFriend(_ nickname: String) -> Single<Result<Bool, Error>>
+    func requestFriend(_ nickname: String) -> Single<Result<ReqeustFriendResult, Error>>
 }
 
 class SearchFriendRepository: NSObject, SearchFriendRepositoryProtocol {
@@ -56,28 +56,65 @@ class SearchFriendRepository: NSObject, SearchFriendRepositoryProtocol {
         }
     }
     
-    func requestFriend(_ nickname: String) -> RxSwift.Single<Result<Bool, Error>> {
-        return Single<Result<Bool, Error>>.create { single in
+    func requestFriend(_ nickname: String) -> RxSwift.Single<Result<ReqeustFriendResult, Error>> {
+        return Single<Result<ReqeustFriendResult, Error>>.create { single in
             // 1. dto 변환 없음
             
             // 2. 요청
             let request = self.provider.log.request(.reqeustFriend(nickname: nickname)) { result in
                 switch result {
+                // 이상한 점
+                // Moya에서는 네트워크 통신 성공만 하면 무조건 success로 떨어지는 것으로 알고 있음
+                // 근데, 둘 중 한 명이 이미 요청을 보냄 (400_5) 응답이 올 때, case.failure로 떨어짐
+                // 일단 두 케이스에 모두 조건을 달아둠.
+                    
                 case .success(let response):
-                    if response.statusCode == 200 {
-                        // 성공
-                        single(.success(.success(true)))
-                    } else {
-                        // 실패
+                    if let data = try? response.map(ResponseDTO<Int>.self) {
+                        // 1. 요청 성공
+                        if data.code == "COMMON200" {
+                            single(.success(.success(.success)))
+                        }
+                        
+                        // 2. 이미 상대방이 요청 보낸 적 있음
+                        else if data.code == "COMMON400_5" {
+                            single(.success(.success(.alreadyReceivedRequest)))
+                        }
+                        
+                        // 3. 실패
+                        else {
+                            single(.success(.failure(SampleError(rawValue: response.statusCode)!)))
+                        }
+                    }
+                    
+                    // 3. 실패
+                    else {
                         single(.success(.failure(SampleError(rawValue: response.statusCode)!)))
                     }
                     
                 case .failure(let error):
-                    // 실패
+                    if let response = error.response,
+                       let data = try? JSONDecoder().decode(ResponseDTO<Int>.self, from: response.data) {
+                        // 2. 이미 상대방이 요청 보낸 적 있음
+                        if data.code == "COMMON400_5" {
+                            single(.success(.success(.alreadyReceivedRequest)))
+                        }
+                        
+                        // 4. 실패
+                        else {
+                            single(.success(.failure(error)))
+                        }
+                    }
+                    
+                    // 4. 실패
                     single(.success(.failure(error)))
                 }
             }
             return Disposables.create()
         }
     }
+}
+
+enum ReqeustFriendResult {
+    case success
+    case alreadyReceivedRequest
 }

--- a/TTOON/Domain/UseCase/Friend/SearchFriendUseCase.swift
+++ b/TTOON/Domain/UseCase/Friend/SearchFriendUseCase.swift
@@ -12,7 +12,7 @@ import RxSwift
 protocol SearchFriendUseCaseProtocol {
     // 네트워크
     func searchUserList(_ requestModel: UserListRequestModel) -> Single< Result<[SearchedUserInfoModel], Error> >
-    func requestFriend(_ nickname: String) -> Single<Result<Bool, Error>>
+    func requestFriend(_ nickname: String) -> Single<Result<ReqeustFriendResult, Error>>
 }
 
 class SearchFriendUseCase: SearchFriendUseCaseProtocol {
@@ -29,7 +29,7 @@ class SearchFriendUseCase: SearchFriendUseCaseProtocol {
         return repo.searchUserList(requestModel)
     }
     
-    func requestFriend(_ nickname: String) -> RxSwift.Single<Result<Bool, Error>> {
+    func requestFriend(_ nickname: String) -> RxSwift.Single<Result<ReqeustFriendResult, Error>> {
         return repo.requestFriend(nickname)
     }
     

--- a/TTOON/Presentation/Home/Friend/SearchFriend/ViewController/SearchFriendViewController.swift
+++ b/TTOON/Presentation/Home/Friend/SearchFriend/ViewController/SearchFriendViewController.swift
@@ -96,6 +96,14 @@ extension SearchFriendViewController {
                 owner.mainView.showNoDataView(show: list.isEmpty)
             }
             .disposed(by: disposeBag)
+        
+        reactor.state.map { $0.alreadyRequestedUserNickname }
+            .subscribe(with: self) { owner, value in
+                if !value.isEmpty {
+                    owner.showBottomSheet(nickname: value)
+                }
+            }
+            .disposed(by: disposeBag)
     }
 }
 
@@ -116,5 +124,26 @@ extension SearchFriendViewController {
     }
     private func setSearchBar() {
         mainView.searchBar.delegate = self
+    }
+    
+    // 이미 요청을 받은 유저일 때, 바텀시트
+    private func showBottomSheet(nickname: String) {
+        let vc = FriendListPopUpBottomSheetViewController(
+            title: "'\(nickname)'님에게 \n친구 신청을 받은 상태에요",
+            subTitle: "친구 신청을 수락하러 가보세요!",
+            image: TNImage.highFive_color!,
+            confirmButtonTitle: "확인",
+            cancelButtonTitle: nil
+        )
+                
+        if let sheet = vc.sheetPresentationController {
+            sheet.detents = [.custom { _ in return 368 } ]
+            sheet.prefersGrabberVisible = true
+            sheet.prefersScrollingExpandsWhenScrolledToEdge = false
+            sheet.prefersEdgeAttachedInCompactHeight = true
+            sheet.widthFollowsPreferredContentSizeWhenEdgeAttached = true
+        }
+        
+        present(vc, animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
### PR 작성전 체크 목록

다음 사항들을 체크했는지 확인해봅시다:

- [X]  base branch 꼭 확인하세요!
- [X]  커밋 메세지들이 약속된 형태로 작성되었나요?
- [X]  추가된 내용 또는 수정된 버그에 대해 충분히 테스트 하였나요?
- [X]  아래의 PR 문서에 작성된 내용으로 충분히 공유가 되거나, 문서를 별도로 작성하였나요?

### PR 타입

해당 PR의 주요한 목적은 다음과 같습니다.

- [ ]  Feature
- [ ]  Feature-Append
- [ ]  UI Design
- [X]  QA Fix
- [ ]  Bugfix
- [ ]  Code style update (formatting, local variables)
- [ ]  Refactoring (no functional changes, no api changes)
- [ ]  Build related changes
- [ ]  CI related changes
- [ ]  Documentation content changes
- [ ]  Others

### 관련 지라 티켓 번호

Issue Number: QA

### 주요 내용
- Moya에서는 네트워크 통신 성공만 하면 success로 온다고 알고 있었는데, failure로 응답받음 (COMMON400_5)
- 일단 .success, .failure 모두 조건 달아둠

### 스크린샷
![IMG_178FCD68A653-1](https://github.com/user-attachments/assets/5db1773e-97b3-48de-b753-6f0f35d33a90)
